### PR TITLE
FIX: Handle adding first name to userContext

### DIFF
--- a/src/app/api/createUser/[userId]/route.ts
+++ b/src/app/api/createUser/[userId]/route.ts
@@ -3,7 +3,7 @@ import {
   DynamoDBDocumentClient,
   PutCommand,
 } from '@aws-sdk/lib-dynamodb';
-
+import { DBuser } from '@/app/types/types';
 export async function GET(
   req: Request,
   { params }: { params: { userId: string } }
@@ -22,6 +22,7 @@ export async function GET(
       TableName: process.env.AWS_TABLE_NAME,
       Item: {
         userId: userId,
+        firstName: '',
         savedGames: [],
         createdGames: [],
         isAdmin: false,

--- a/src/app/api/updateUser/[userId]/route.ts
+++ b/src/app/api/updateUser/[userId]/route.ts
@@ -42,7 +42,7 @@ export async function GET(
   };
 
   const response = await updateUser(params.userId);
-  return Response.json(response);
+  return Response.json(firstName);
 }
 
 // Updates a user's saved games

--- a/src/app/components/createGame/NewGameForm.tsx
+++ b/src/app/components/createGame/NewGameForm.tsx
@@ -373,7 +373,6 @@ export default function NewGameForm({ editGame }: { editGame?: string }) {
           body: JSON.stringify(newGame),
         });
         const data = await response.json();
-        console.log('response from createGame: ', data)
       }
     }
 
@@ -385,7 +384,6 @@ export default function NewGameForm({ editGame }: { editGame?: string }) {
         body: JSON.stringify({ savedGame: newGame.id }),
       });
       const data = await response.json();
-      console.log('response from adding game to saved games array: ', data)
     }
   };
 

--- a/src/app/components/layout/Header.tsx
+++ b/src/app/components/layout/Header.tsx
@@ -15,11 +15,11 @@ export default function Header() {
       const data = await response.json();
       return data;
     };
-
+       
     const updateUser = async (userId: string | undefined) => {
       const response = await fetch(`/api/updateUser/${userId}`);
       const data = await response.json();
-      return data;
+      return data.Attributes.firstName;
     };
 
     const fetchUser = async (id: string | undefined | null) => {
@@ -29,7 +29,6 @@ export default function Header() {
         setUser({
           id: data.userId,
           firstName: data.firstName,
-          nickName: data.nickName,
           savedGames: data.savedGames,
           createdGames: data.createdGames,
           isAdmin: data.isAdmin,
@@ -50,7 +49,6 @@ export default function Header() {
           setUser({
             id: data.userId,
             firstName: data.firstName,
-            nickName: data.nickName,
             savedGames: data.savedGames,
             createdGames: data.createdGames,
             isAdmin: data.isAdmin,
@@ -63,7 +61,6 @@ export default function Header() {
         setUser({
           id: '',
           firstName: '',
-          nickName: '',
           savedGames: [],
           createdGames: [],
           isAdmin: false,

--- a/src/app/contexts/savedGamesContext.tsx
+++ b/src/app/contexts/savedGamesContext.tsx
@@ -30,7 +30,7 @@ const SavedGamesContextProvider = (props: PropsWithChildren<{}>) => {
   const { user } = useContext(UserContext);
 
   useEffect(() => {
-    console.log('user: ', user);
+    // console.log('user: ', user);
     const fetchData = async () => {
       setLoadingSavedGames(true);
       const response = await fetch(`/api/games/${user.id}`);

--- a/src/app/contexts/userContext.tsx
+++ b/src/app/contexts/userContext.tsx
@@ -12,7 +12,6 @@ const defaultContextValue: DBuserContextType = {
   user: {
     id: '',
     firstName: '',
-    nickName: '',
     savedGames: [],
     createdGames: [],
     isAdmin: false,
@@ -27,7 +26,6 @@ const UserContextProvider = (props: PropsWithChildren<{}>) => {
   const [user, setUser] = useState<DBuser>({
     id: '',
     firstName: '',
-    nickName: '',
     savedGames: [],
     createdGames: [],
     isAdmin: false,

--- a/src/app/types/types.ts
+++ b/src/app/types/types.ts
@@ -23,7 +23,6 @@ export interface Challenge {
 export interface DBuser {
   id: string;
   firstName: string;
-  nickName: string;
   savedGames: string[];
   createdGames: string[];
   isAdmin: boolean;


### PR DESCRIPTION
Alright! I think I solved the issue. I have an `updateUser` function that returns the first name to the `userContext` - the only reason I want this is to add the user's first name to the game when they create it.

Anyway, it was returning a response object from using the AWS SDK - but we just need the actual first name. I simply return the first name from the `currentUser` object that is only accessible on the server, so it will add it to the front end even if updating the database fails.

There should be error handling if that is the case, but for now at least the first name will exist and no fatal errors will occur on the front-end.